### PR TITLE
Fixed typo for stickied comments pull

### DIFF
--- a/reddift/Model/Comment.swift
+++ b/reddift/Model/Comment.swift
@@ -254,6 +254,7 @@ public struct Comment: Thing {
         modReports = link.modReports
         numReports = link.numReports
         ups = link.ups
+	stickied = false
     }
     
     /**


### PR DESCRIPTION
I forgot to include  `stickied = false` for the second option for init